### PR TITLE
Feat/TAS-54 -  User Detail Page

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,14 +1,118 @@
-'use-client';
+'use client';
 
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@apollo/client';
+import { CURRENT_USER, MY_RECIPE_LIST_QUERY } from '@/features/user/services/query';
+import { client } from '@/lib/apollo-client';
 import { ProfileView } from '@/features/user/components/ProfileView';
-import ProtectedRoute from '@/routes/ProtectedRoute';
-
-// import { button } from '@/components/ui/button';
+import useSnackbar from '@/core/hooks/useSnackbar';
 
 export default function ProfilePage() {
+  const router = useRouter();
+  const { showError } = useSnackbar();
+  const [searchQuery, setSearchQuery] = React.useState('');
+
+  // Fetch current user
+  const { loading: userLoading, error: userError, data: userData } = useQuery(CURRENT_USER, {
+    client,
+    fetchPolicy: 'network-only',
+  });
+
+  // Fetch user's recipes
+  const {
+    loading: recipesLoading,
+    error: recipesError,
+    data: recipesData,
+    fetchMore,
+  } = useQuery(MY_RECIPE_LIST_QUERY, {
+    variables: {
+      search: searchQuery || undefined,
+      limit: 24,
+      after: undefined,
+    },
+    skip: !userData?.currentUser,
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+  });
+
+  // Handle token expired error
+  useEffect(() => {
+    if (userError) {
+      const errorMessage = userError.message.toLowerCase();
+      if (
+        errorMessage.includes('token') &&
+        (errorMessage.includes('expired') ||
+          errorMessage.includes('invalid') ||
+          errorMessage.includes('unauthorized'))
+      ) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        showError('Token expired. Please login again.');
+        setTimeout(() => {
+          router.push('/');
+        }, 2000);
+        return;
+      }
+    }
+  }, [userError, showError, router]);
+
+  if (userLoading) return <p>Loading...</p>;
+  if (userError && !userError.message.toLowerCase().includes('token'))
+    return <p>Error: {userError.message}</p>;
+
+  const { username, fullname, image } = userData.currentUser;
+  const recipes = recipesData?.myRecipeList?.recipes || [];
+  const meta = recipesData?.myRecipeList?.meta || { total: 0, hasNextPage: false };
+
+  const handleFetchMore = (cursor: string) => {
+    fetchMore({
+      variables: { after: cursor },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          myRecipeList: {
+            ...fetchMoreResult.myRecipeList,
+            recipes: [
+              ...prev.myRecipeList.recipes,
+              ...fetchMoreResult.myRecipeList.recipes,
+            ],
+          },
+        };
+      },
+    });
+  };
+
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query);
+  };
+
+  const handleEditProfile = () => {
+    router.push('/profile/edit');
+  };
+
   return (
-    <ProtectedRoute>
-      <ProfileView />
-    </ProtectedRoute>
+    <ProfileView
+      username={username}
+      fullname={fullname}
+      image={image}
+      stats={{
+        posts: meta.total,
+        following: 0,
+        followers: 0,
+      }}
+      recipes={recipes}
+      recipesLoading={recipesLoading}
+      recipesError={recipesError}
+      recipesMeta={meta}
+      onFetchMore={handleFetchMore}
+      onSearchChange={handleSearchChange}
+      actionButton={{
+        label: 'Edit Profile',
+        onClick: handleEditProfile,
+        variant: 'edit',
+      }}
+      isOwnProfile={true}
+    />
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -189,8 +189,7 @@ const SearchResultsPage: React.FC = () => {
   }, [searchQuery, router]);
 
   const handleUserClick = (userId: string) => {
-    // TODO: Navigate to user profile
-    console.log('Navigate to user:', userId);
+    router.push(`/users/${userId}`);
   };
 
   const handleFollowToggle = (userId: string, e: React.MouseEvent) => {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,0 +1,382 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@apollo/client';
+import { USER_PROFILE_QUERY, USER_RECIPE_LIST_QUERY } from '@/features/user/services/query';
+import { Avatar } from '@/core/components/image/Avatar';
+import RecipeCard from '@/core/components/RecipeCard/RecipeCard';
+import useSnackbar from '@/core/hooks/useSnackbar';
+import Snackbar from '@/core/components/snackbar/Snackbar';
+
+// TypeScript interfaces
+interface RecipeImage {
+  url: string;
+}
+
+interface RecipeIngredient {
+  id: string;
+  ingredient: string;
+}
+
+interface RecipeInstruction {
+  id: string;
+  instruction: string;
+}
+
+interface UserRecipe {
+  id: string;
+  title: string;
+  description?: string;
+  servings?: number;
+  cookingTime?: number;
+  image?: RecipeImage;
+  ingredients?: RecipeIngredient[];
+  instructions?: RecipeInstruction[];
+}
+
+interface UserRecipeListData {
+  userRecipeList: {
+    recipes: UserRecipe[];
+    meta: {
+      total: number;
+      endCursor?: string;
+      hasNextPage: boolean;
+    };
+  };
+}
+
+interface FollowerFollowing {
+  id: string;
+  username: string;
+}
+
+interface UserProfileData {
+  userProfile: {
+    id: string;
+    fullname: string;
+    username: string;
+    email: string;
+    birthDate?: string;
+    image?: string;
+    followers: {
+      data: FollowerFollowing[];
+      total: number;
+    };
+    following: {
+      data: FollowerFollowing[];
+      total: number;
+    };
+  };
+}
+
+interface UserDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function UserDetailPage({ params }: UserDetailPageProps) {
+  const router = useRouter();
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+  const [openMenuIndex, setOpenMenuIndex] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [userIdInt, setUserIdInt] = useState<number | null>(null);
+  const {
+    error: snackbarError,
+    showError,
+    handleCloseSnackbar,
+  } = useSnackbar();
+
+  // Resolve params
+  useEffect(() => {
+    params.then((resolvedParams) => {
+      setUserId(resolvedParams.id);
+      setUserIdInt(parseInt(resolvedParams.id, 10));
+    });
+  }, [params]);
+
+  // Debounce search query - 500ms delay, minimum 3 characters
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchQuery.length >= 3 || searchQuery.length === 0) {
+        setDebouncedSearchQuery(searchQuery);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Fetch user profile
+  const {
+    loading: userLoading,
+    error: userError,
+    data: userData,
+  } = useQuery<UserProfileData>(USER_PROFILE_QUERY, {
+    variables: { id: userId },
+    skip: !userId,
+    fetchPolicy: 'network-only',
+  });
+
+  // Fetch user's recipes
+  const {
+    loading: recipesLoading,
+    error: recipesError,
+    data: recipesData,
+    fetchMore,
+  } = useQuery<UserRecipeListData>(USER_RECIPE_LIST_QUERY, {
+    variables: {
+      userId: userIdInt,
+      search: debouncedSearchQuery || undefined,
+      limit: 24,
+      after: undefined,
+    },
+    skip: !userIdInt,
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+  });
+
+  // Handle user profile error
+  useEffect(() => {
+    if (userError) {
+      showError(userError.message || 'Failed to load user profile');
+    }
+  }, [userError, showError]);
+
+  // Handle recipes error
+  useEffect(() => {
+    if (recipesError) {
+      showError(recipesError.message || 'Failed to load recipes');
+    }
+  }, [recipesError, showError]);
+
+  const recipes = recipesData?.userRecipeList?.recipes || [];
+  const meta = recipesData?.userRecipeList?.meta || {
+    total: 0,
+    hasNextPage: false,
+  };
+
+  // Infinite scroll
+  useEffect(() => {
+    if (!meta.hasNextPage || recipesLoading || isFetchingMore) return;
+    const currentLoader = loaderRef.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && meta.endCursor) {
+          setIsFetchingMore(true);
+          fetchMore({
+            variables: { after: meta.endCursor },
+            updateQuery: (prev, { fetchMoreResult }) => {
+              setIsFetchingMore(false);
+              if (!fetchMoreResult) return prev;
+              return {
+                userRecipeList: {
+                  ...fetchMoreResult.userRecipeList,
+                  recipes: [
+                    ...prev.userRecipeList.recipes,
+                    ...fetchMoreResult.userRecipeList.recipes,
+                  ],
+                },
+              };
+            },
+          });
+        }
+      },
+      { threshold: 1 }
+    );
+    if (currentLoader) observer.observe(currentLoader);
+    return () => {
+      if (currentLoader) observer.unobserve(currentLoader);
+    };
+  }, [
+    meta.hasNextPage,
+    meta.endCursor,
+    recipesLoading,
+    fetchMore,
+    isFetchingMore,
+  ]);
+
+  if (userLoading || !userId) return <p>Loading...</p>;
+  if (userError || !userData?.userProfile)
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
+        <Image
+          src="/images/broken-image.png"
+          alt="Error"
+          width={128}
+          height={128}
+          className="mb-6 opacity-60"
+        />
+        <h2 className="text-2xl font-bold mb-2 text-gray-700">
+          User Not Found
+        </h2>
+        <p className="text-gray-500 mb-4">
+          Sorry, the user you are looking for does not exist.
+        </p>
+        <button
+          onClick={() => router.push('/users')}
+          className="text-primary font-semibold hover:underline"
+        >
+          Back to Users
+        </button>
+      </div>
+    );
+
+  const { username, fullname, image, followers, following } = userData.userProfile;
+
+  const handleCardClick = (recipeId: string) => {
+    router.push(`/recipes/${recipeId}`);
+  };
+
+  const handleBookmark = (idx: number, e: React.MouseEvent<Element>) => {
+    e.stopPropagation();
+    // TODO: Implement bookmark functionality
+  };
+
+  const handleMenu = (idx: number, e: React.MouseEvent<Element>) => {
+    e.stopPropagation();
+    setOpenMenuIndex(idx === openMenuIndex ? null : idx);
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <div>
+      {/* Profile Section */}
+      <main className="max-w-3xl mx-auto px-4 md:px-20 lg:px-40 py-8">
+        <div className="flex flex-col text-center mb-8">
+          <Avatar
+            imageUrl={image}
+            fullName={fullname}
+            className="w-24 h-24 mx-auto mb-4"
+          />
+          <h1 className="text-xl font-semibold mb-1 mx-auto text-center truncate max-w-[200px] sm:max-w-[200px] md:max-w-[350px] lg:max-w-[400px]">
+            {fullname}
+          </h1>
+          <p className="text-gray-500 mb-4">{`@${username}`}</p>
+          <div className="flex justify-center gap-6 mb-4">
+            <div className="text-center">
+              <p className="font-semibold">{meta.total}</p>
+              <p className="text-gray-500 text-sm">Posts</p>
+            </div>
+            <div className="text-center">
+              <p className="font-semibold">{following.total}</p>
+              <p className="text-gray-500 text-sm">Following</p>
+            </div>
+            <div className="text-center">
+              <p className="font-semibold">{followers.total}</p>
+              <p className="text-gray-500 text-sm">Followers</p>
+            </div>
+          </div>
+          {/* Follow Button */}
+          <div className="flex justify-center">
+            <button
+              type="button"
+              className="w-full py-2 bg-primary text-white font-semibold rounded-3xl hover:bg-orange-600 transition active:scale-95"
+              onClick={() => {
+                // TODO: Implement follow functionality
+              }}
+            >
+              Follow
+            </button>
+          </div>
+        </div>
+      </main>
+
+      {/* Recipe Section */}
+      <div className="w-full py-6 sm:py-8 md:py-12 bg-gray-50">
+        <div className="max-w-6xl mx-auto px-4 md:px-8 lg:px-12">
+          {/* Search Field */}
+          <div className="mb-6 max-w-md mx-auto">
+            <input
+              type="text"
+              placeholder="Search..."
+              value={searchQuery}
+              onChange={handleSearchChange}
+              className="w-full px-4 py-2 border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            />
+          </div>
+
+          {/* Loading State */}
+          {recipesLoading && recipes.length === 0 && (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!recipesLoading && recipes.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-12">
+              <div className="w-16 h-16 mx-auto mb-4">
+                <Image
+                  src="https://global-web-assets.cpcdn.com/assets/empty_states/no_results-8613ba06d717993e5429d9907d209dc959106472a8a4089424f1b0ccbbcd5fa9.svg"
+                  alt="Empty bowl"
+                  width={64}
+                  height={64}
+                  className="opacity-50"
+                />
+              </div>
+              <h2 className="text-xl font-semibold mb-2">
+                {searchQuery ? 'No recipes found' : 'No recipes yet.'}
+              </h2>
+              <p className="text-gray-500 mb-4">
+                {searchQuery
+                  ? 'Try a different search term'
+                  : 'This user has not posted any recipes yet.'}
+              </p>
+            </div>
+          )}
+
+          {/* Recipe Grid */}
+          {recipes.length > 0 && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 justify-items-center">
+              {recipes.map((recipe, idx) => (
+                <RecipeCard
+                  key={recipe.id}
+                  title={recipe.title}
+                  img={recipe.image?.url || '/images/broken-image.png'}
+                  rating={0}
+                  ingredients={recipe.ingredients?.length || 0}
+                  author={fullname}
+                  authorAvatar={image || ''}
+                  isBookmarked={false}
+                  time={
+                    recipe.cookingTime ? `${recipe.cookingTime} min` : 'N/A'
+                  }
+                  onClick={() => handleCardClick(recipe.id)}
+                  onBookmark={(e) => handleBookmark(idx, e)}
+                  onMenu={(e) => handleMenu(idx, e)}
+                  menuOpen={openMenuIndex === idx}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Loader for infinite scroll */}
+          <div ref={loaderRef} className="h-8 mt-4" />
+          {(recipesLoading || isFetchingMore) && recipes.length > 0 && (
+            <div className="flex justify-center py-6">
+              <span className="w-8 h-8 rounded-full border-4 border-gray-300 border-t-primary animate-spin" />
+            </div>
+          )}
+          {!meta.hasNextPage && recipes.length > 0 && (
+            <div className="text-center text-gray-400 py-8">
+              No more recipes
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Snackbar for error messages */}
+      <Snackbar
+        variant="error"
+        message={snackbarError}
+        onClose={handleCloseSnackbar}
+      />
+    </div>
+  );
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client';
@@ -8,71 +8,8 @@ import {
   USER_PROFILE_QUERY,
   USER_RECIPE_LIST_QUERY,
 } from '@/features/user/services/query';
-import { Avatar } from '@/core/components/image/Avatar';
-import RecipeCard from '@/core/components/RecipeCard/RecipeCard';
+import { ProfileView } from '@/features/user/components/ProfileView';
 import useSnackbar from '@/core/hooks/useSnackbar';
-import Snackbar from '@/core/components/snackbar/Snackbar';
-
-// TypeScript interfaces
-interface RecipeImage {
-  url: string;
-}
-
-interface RecipeIngredient {
-  id: string;
-  ingredient: string;
-}
-
-interface RecipeInstruction {
-  id: string;
-  instruction: string;
-}
-
-interface UserRecipe {
-  id: string;
-  title: string;
-  description?: string;
-  servings?: number;
-  cookingTime?: number;
-  image?: RecipeImage;
-  ingredients?: RecipeIngredient[];
-  instructions?: RecipeInstruction[];
-}
-
-interface UserRecipeListData {
-  userRecipeList: {
-    recipes: UserRecipe[];
-    meta: {
-      total: number;
-      endCursor?: string;
-      hasNextPage: boolean;
-    };
-  };
-}
-
-interface FollowerFollowing {
-  id: string;
-  username: string;
-}
-
-interface UserProfileData {
-  userProfile: {
-    id: string;
-    fullname: string;
-    username: string;
-    email: string;
-    birthDate?: string;
-    image?: string;
-    followers: {
-      data: FollowerFollowing[];
-      total: number;
-    };
-    following: {
-      data: FollowerFollowing[];
-      total: number;
-    };
-  };
-}
 
 interface UserDetailPageProps {
   params: Promise<{ id: string }>;
@@ -80,18 +17,10 @@ interface UserDetailPageProps {
 
 export default function UserDetailPage({ params }: UserDetailPageProps) {
   const router = useRouter();
-  const loaderRef = useRef<HTMLDivElement | null>(null);
-  const [openMenuIndex, setOpenMenuIndex] = useState<number | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
-  const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [userIdInt, setUserIdInt] = useState<number | null>(null);
-  const {
-    error: snackbarError,
-    showError,
-    handleCloseSnackbar,
-  } = useSnackbar();
+  const [searchQuery, setSearchQuery] = useState('');
+  const { showError } = useSnackbar();
 
   // Resolve params
   useEffect(() => {
@@ -101,23 +30,12 @@ export default function UserDetailPage({ params }: UserDetailPageProps) {
     });
   }, [params]);
 
-  // Debounce search query - 500ms delay, minimum 3 characters
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (searchQuery.length >= 3 || searchQuery.length === 0) {
-        setDebouncedSearchQuery(searchQuery);
-      }
-    }, 500);
-
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
-
   // Fetch user profile
   const {
     loading: userLoading,
     error: userError,
     data: userData,
-  } = useQuery<UserProfileData>(USER_PROFILE_QUERY, {
+  } = useQuery(USER_PROFILE_QUERY, {
     variables: { id: userId },
     skip: !userId,
     fetchPolicy: 'network-only',
@@ -129,10 +47,10 @@ export default function UserDetailPage({ params }: UserDetailPageProps) {
     error: recipesError,
     data: recipesData,
     fetchMore,
-  } = useQuery<UserRecipeListData>(USER_RECIPE_LIST_QUERY, {
+  } = useQuery(USER_RECIPE_LIST_QUERY, {
     variables: {
       userId: userIdInt,
-      search: debouncedSearchQuery || undefined,
+      search: searchQuery || undefined,
       limit: 24,
       after: undefined,
     },
@@ -147,59 +65,6 @@ export default function UserDetailPage({ params }: UserDetailPageProps) {
       showError(userError.message || 'Failed to load user profile');
     }
   }, [userError, showError]);
-
-  // Handle recipes error
-  useEffect(() => {
-    if (recipesError) {
-      showError(recipesError.message || 'Failed to load recipes');
-    }
-  }, [recipesError, showError]);
-
-  const recipes = recipesData?.userRecipeList?.recipes || [];
-  const meta = recipesData?.userRecipeList?.meta || {
-    total: 0,
-    hasNextPage: false,
-  };
-
-  // Infinite scroll
-  useEffect(() => {
-    if (!meta.hasNextPage || recipesLoading || isFetchingMore) return;
-    const currentLoader = loaderRef.current;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && meta.endCursor) {
-          setIsFetchingMore(true);
-          fetchMore({
-            variables: { after: meta.endCursor },
-            updateQuery: (prev, { fetchMoreResult }) => {
-              setIsFetchingMore(false);
-              if (!fetchMoreResult) return prev;
-              return {
-                userRecipeList: {
-                  ...fetchMoreResult.userRecipeList,
-                  recipes: [
-                    ...prev.userRecipeList.recipes,
-                    ...fetchMoreResult.userRecipeList.recipes,
-                  ],
-                },
-              };
-            },
-          });
-        }
-      },
-      { threshold: 1 }
-    );
-    if (currentLoader) observer.observe(currentLoader);
-    return () => {
-      if (currentLoader) observer.unobserve(currentLoader);
-    };
-  }, [
-    meta.hasNextPage,
-    meta.endCursor,
-    recipesLoading,
-    fetchMore,
-    isFetchingMore,
-  ]);
 
   if (userLoading || !userId) return <p>Loading...</p>;
   if (userError || !userData?.userProfile)
@@ -229,158 +94,62 @@ export default function UserDetailPage({ params }: UserDetailPageProps) {
 
   const { username, fullname, image, followers, following } =
     userData.userProfile;
-
-  const handleCardClick = (recipeId: string) => {
-    router.push(`/recipes/${recipeId}`);
+  const recipes = recipesData?.userRecipeList?.recipes || [];
+  const meta = recipesData?.userRecipeList?.meta || {
+    total: 0,
+    hasNextPage: false,
   };
 
-  const handleBookmark = (idx: number, e: React.MouseEvent<Element>) => {
-    e.stopPropagation();
-    // TODO: Implement bookmark functionality
+  const handleFetchMore = (cursor: string) => {
+    fetchMore({
+      variables: { after: cursor },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          userRecipeList: {
+            ...fetchMoreResult.userRecipeList,
+            recipes: [
+              ...prev.userRecipeList.recipes,
+              ...fetchMoreResult.userRecipeList.recipes,
+            ],
+          },
+        };
+      },
+    });
   };
 
-  const handleMenu = (idx: number, e: React.MouseEvent<Element>) => {
-    e.stopPropagation();
-    setOpenMenuIndex(idx === openMenuIndex ? null : idx);
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query);
   };
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
+  const handleFollowClick = () => {
+    // TODO: Implement follow functionality
+    console.log('Follow user:', userId);
   };
 
   return (
-    <div>
-      {/* Profile Section */}
-      <main className="max-w-3xl mx-auto px-4 md:px-20 lg:px-40 py-8">
-        <div className="flex flex-col text-center mb-8">
-          <Avatar
-            imageUrl={image}
-            fullName={fullname}
-            className="w-24 h-24 mx-auto mb-4"
-          />
-          <h1 className="text-xl font-semibold mb-1 mx-auto text-center truncate max-w-[200px] sm:max-w-[200px] md:max-w-[350px] lg:max-w-[400px]">
-            {fullname}
-          </h1>
-          <p className="text-gray-500 mb-4">{`@${username}`}</p>
-          <div className="flex justify-center gap-6 mb-4">
-            <div className="text-center">
-              <p className="font-semibold">{meta.total}</p>
-              <p className="text-gray-500 text-sm">Posts</p>
-            </div>
-            <div className="text-center">
-              <p className="font-semibold">{following.total}</p>
-              <p className="text-gray-500 text-sm">Following</p>
-            </div>
-            <div className="text-center">
-              <p className="font-semibold">{followers.total}</p>
-              <p className="text-gray-500 text-sm">Followers</p>
-            </div>
-          </div>
-          {/* Follow Button */}
-          <div className="flex justify-center">
-            <button
-              type="button"
-              className="w-full py-2 bg-primary text-white font-semibold rounded-3xl hover:bg-orange-600 transition active:scale-95"
-              onClick={() => {
-                // TODO: Implement follow functionality
-              }}
-            >
-              Follow
-            </button>
-          </div>
-        </div>
-      </main>
-
-      {/* Recipe Section */}
-      <div className="w-full py-6 sm:py-8 md:py-12 bg-gray-50">
-        <div className="max-w-6xl mx-auto px-4 md:px-8 lg:px-12">
-          {/* Search Field */}
-          <div className="mb-6 max-w-md mx-auto">
-            <input
-              type="text"
-              placeholder="Search..."
-              value={searchQuery}
-              onChange={handleSearchChange}
-              className="w-full px-4 py-2 border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            />
-          </div>
-
-          {/* Loading State */}
-          {recipesLoading && recipes.length === 0 && (
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
-            </div>
-          )}
-
-          {/* Empty State */}
-          {!recipesLoading && recipes.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-12">
-              <div className="w-16 h-16 mx-auto mb-4">
-                <Image
-                  src="https://global-web-assets.cpcdn.com/assets/empty_states/no_results-8613ba06d717993e5429d9907d209dc959106472a8a4089424f1b0ccbbcd5fa9.svg"
-                  alt="Empty bowl"
-                  width={64}
-                  height={64}
-                  className="opacity-50"
-                />
-              </div>
-              <h2 className="text-xl font-semibold mb-2">
-                {searchQuery ? 'No recipes found' : 'No recipes yet.'}
-              </h2>
-              <p className="text-gray-500 mb-4">
-                {searchQuery
-                  ? 'Try a different search term'
-                  : 'This user has not posted any recipes yet.'}
-              </p>
-            </div>
-          )}
-
-          {/* Recipe Grid */}
-          {recipes.length > 0 && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 justify-items-center">
-              {recipes.map((recipe, idx) => (
-                <RecipeCard
-                  key={recipe.id}
-                  title={recipe.title}
-                  img={recipe.image?.url || '/images/broken-image.png'}
-                  rating={0}
-                  ingredients={recipe.ingredients?.length || 0}
-                  author={fullname}
-                  authorAvatar={image || ''}
-                  isBookmarked={false}
-                  time={
-                    recipe.cookingTime ? `${recipe.cookingTime} min` : 'N/A'
-                  }
-                  onClick={() => handleCardClick(recipe.id)}
-                  onBookmark={(e) => handleBookmark(idx, e)}
-                  onMenu={(e) => handleMenu(idx, e)}
-                  menuOpen={openMenuIndex === idx}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* Loader for infinite scroll */}
-          <div ref={loaderRef} className="h-8 mt-4" />
-          {(recipesLoading || isFetchingMore) && recipes.length > 0 && (
-            <div className="flex justify-center py-6">
-              <span className="w-8 h-8 rounded-full border-4 border-gray-300 border-t-primary animate-spin" />
-            </div>
-          )}
-          {!meta.hasNextPage && recipes.length > 0 && (
-            <div className="text-center text-gray-400 py-8">
-              No more recipes
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Snackbar for error messages */}
-      <Snackbar
-        variant="error"
-        message={snackbarError}
-        onClose={handleCloseSnackbar}
-      />
-    </div>
+    <ProfileView
+      username={username}
+      fullname={fullname}
+      image={image}
+      stats={{
+        posts: meta.total,
+        following: following.total,
+        followers: followers.total,
+      }}
+      recipes={recipes}
+      recipesLoading={recipesLoading}
+      recipesError={recipesError}
+      recipesMeta={meta}
+      onFetchMore={handleFetchMore}
+      onSearchChange={handleSearchChange}
+      actionButton={{
+        label: 'Follow',
+        onClick: handleFollowClick,
+        variant: 'follow',
+      }}
+      isOwnProfile={false}
+      emptyStateMessage="No recipes yet."
+    />
   );
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client';
-import { USER_PROFILE_QUERY, USER_RECIPE_LIST_QUERY } from '@/features/user/services/query';
+import {
+  USER_PROFILE_QUERY,
+  USER_RECIPE_LIST_QUERY,
+} from '@/features/user/services/query';
 import { Avatar } from '@/core/components/image/Avatar';
 import RecipeCard from '@/core/components/RecipeCard/RecipeCard';
 import useSnackbar from '@/core/hooks/useSnackbar';
@@ -224,7 +227,8 @@ export default function UserDetailPage({ params }: UserDetailPageProps) {
       </div>
     );
 
-  const { username, fullname, image, followers, following } = userData.userProfile;
+  const { username, fullname, image, followers, following } =
+    userData.userProfile;
 
   const handleCardClick = (recipeId: string) => {
     router.push(`/recipes/${recipeId}`);

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client';
 import Image from 'next/image';
 import UserCard from '@/core/components/UserCard/UserCard';
@@ -29,6 +29,7 @@ interface UsersData {
 const UsersPage: React.FC = () => {
   const searchParams = useSearchParams();
   const searchQuery = searchParams?.get('search_query') || '';
+  const router = useRouter();
   const loaderRef = useRef<HTMLDivElement | null>(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [followingUsers, setFollowingUsers] = useState<Set<string>>(new Set());
@@ -101,8 +102,7 @@ const UsersPage: React.FC = () => {
   };
 
   const handleUserClick = (userId: string) => {
-    // TODO: Navigate to user profile
-    console.log('Navigate to user:', userId);
+    router.push(`/users/${userId}`);
   };
 
   return (

--- a/src/features/user/services/query.ts
+++ b/src/features/user/services/query.ts
@@ -49,17 +49,76 @@ export const MY_RECIPE_LIST_QUERY = gql`
         }
         ingredients {
           id
+          name
+          quantity
+          unit
+        }
+        instructions {
+          id
+          stepNumber
+          instruction
+        }
+        author {
+          id
+          name
+          email
+        }
+      }
+      meta {
+        total
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+export const USER_PROFILE_QUERY = gql`
+  query UserProfile($id: ID!) {
+    userProfile(id: $id) {
+      id
+      fullname
+      username
+      email
+      birthDate
+      image
+      followers {
+        data {
+          id
+          username
+        }
+        total
+      }
+      following {
+        data {
+          id
+          username
+        }
+        total
+      }
+    }
+  }
+`;
+
+export const USER_RECIPE_LIST_QUERY = gql`
+  query UserRecipeList($userId: Int!, $search: String, $after: String, $limit: Int) {
+    userRecipeList(userId: $userId, search: $search, after: $after, limit: $limit) {
+      recipes {
+        id
+        title
+        description
+        servings
+        cookingTime
+        image {
+          url
+        }
+        ingredients {
+          id
           ingredient
         }
         instructions {
           id
           instruction
-        }
-        author {
-          id
-          username
-          fullname
-          email
         }
       }
       meta {

--- a/src/features/user/services/query.ts
+++ b/src/features/user/services/query.ts
@@ -49,18 +49,16 @@ export const MY_RECIPE_LIST_QUERY = gql`
         }
         ingredients {
           id
-          name
-          quantity
-          unit
+          ingredient
         }
         instructions {
           id
-          stepNumber
           instruction
         }
         author {
           id
-          name
+          username
+          fullname
           email
         }
       }
@@ -101,8 +99,18 @@ export const USER_PROFILE_QUERY = gql`
 `;
 
 export const USER_RECIPE_LIST_QUERY = gql`
-  query UserRecipeList($userId: Int!, $search: String, $after: String, $limit: Int) {
-    userRecipeList(userId: $userId, search: $search, after: $after, limit: $limit) {
+  query UserRecipeList(
+    $userId: Int!
+    $search: String
+    $after: String
+    $limit: Int
+  ) {
+    userRecipeList(
+      userId: $userId
+      search: $search
+      after: $after
+      limit: $limit
+    ) {
       recipes {
         id
         title


### PR DESCRIPTION
refactor(profile): make ProfileView reusable component with props-based configuration

- Convert ProfileView from page-specific to reusable component
- Add props for user data, stats, recipes, and callbacks
- Implement configurable action button (edit/follow/following)
- Separate data fetching logic from presentation component
- Support both own profile and other user profiles

Technical changes:
- Update src/features/user/components/ProfileView.tsx:
  * Add comprehensive props interface (ProfileViewProps)
  * Convert to pure presentation component
  * Add actionButton prop with variant support (edit/follow/following)
  * Add onSearchChange and onFetchMore callback props
  * Add isOwnProfile flag for conditional rendering
  * Add emptyStateMessage prop for customization
  * Implement dynamic button styling based on variant
  * Keep internal state for search, debounce, and infinite scroll

- Refactor src/app/profile/page.tsx:
  * Move GraphQL queries to page wrapper
  * Pass data to ProfileView via props
  * Implement Edit Profile button via actionButton prop
  * Calculate stats from API response

- Refactor src/app/users/[id]/page.tsx:
  * Move GraphQL queries to page wrapper
  * Pass user data to ProfileView via props
  * Implement Follow button via actionButton prop
  * Handle search state in parent component
  * Pass followers/following counts from API

Benefits:
- Single source of truth for profile UI
- Easy to maintain and test
- Flexible configuration via props
- Supports multiple use cases (own profile vs user profile)
- No code duplication between profile pages
- Clean separation of concerns (data vs presentation)

Features preserved:
- Debounced search (500ms, min 3 chars)
- Infinite scroll pagination
- Loading and error states
- Responsive grid layout
- Recipe card interactions
- Snackbar error handling

Co-authored-by: GitHub Copilot <copilot@github.com>