### PR TITLE
feat(feed): add image carousel with anchored lightbox preview

### DIFF
--- a/.github/prompts/plan-feedCardImageCarousel.prompt.md
+++ b/.github/prompts/plan-feedCardImageCarousel.prompt.md
@@ -1,0 +1,98 @@
+# Plan: Feed Card Image Carousel + Lightbox
+
+This adds a reusable `FeedImageCarousel` component that handles multi-image scroll-snap carousel display and `yet-another-react-lightbox` with a zoom-from-card open animation. Two consumer components are updated: `FeedPostCard` (home feed) and `UserPostsList` (profile feed). No API/GraphQL changes — only the data-mapping in `transformFeedData` is extended to forward all image URLs.
+
+---
+
+## Steps
+
+### 1. Create `src/core/components/FeedImageCarousel/FeedImageCarousel.tsx`
+
+A self-contained component accepting:
+
+- `images: string[]` — ordered image URLs
+- `aspectRatio?: string` — Tailwind class (default `"aspect-[4/3]"`)
+
+**Carousel markup:**
+
+- Outer wrapper: `relative w-full overflow-hidden` with the given aspect ratio, holds a `ref` for origin tracking
+- Inner scroll container: `flex overflow-x-auto snap-x snap-mandatory scrollbar-hide [scroll-behavior:smooth]`; each slide is `flex-none w-full h-full snap-center`; each slide has a `cursor-pointer` `<Image fill className="object-cover">` with an `onClick` handler calling `openLightbox(index)`
+- When `images.length > 1`: render semi-transparent prev/next `<button>` arrows (absolute left/right, vertically centered), and dot indicators (absolute bottom-center); prev/next call `scrollRef.current.scrollTo({ left: index * width, behavior: 'smooth' })`; dots reflect current index tracked via a `scroll` event listener computing `Math.round(scrollLeft / scrollWidth * count)`
+- Single image: render just the image (no arrows/dots), same click-to-open
+
+**Lightbox:**
+
+- State: `open: boolean`, `index: number`; `originX`/`originY` strings (CSS values, e.g. `"42.3%"` / `"61.7%"`)
+- `openLightbox(i)`: reads `containerRef.current.getBoundingClientRect()`, computes `originX = ((rect.left + rect.width/2) / window.innerWidth * 100).toFixed(1) + '%'` and `originY` similarly, sets all four state values
+- Renders `<Lightbox>` from `yet-another-react-lightbox` with:
+  - `open / close / index / slides` props
+  - `plugins={[Zoom]}` (Zoom plugin only)
+  - `carousel={{ imageFit: 'contain', finite: images.length === 1 }}`
+  - `animation={{ fade: 220 }}`
+  - `classNames={{ root: 'yarl__card-origin' }}` — references a global keyframe class
+  - `styles={{ root: { '--card-ox': originX, '--card-oy': originY } as React.CSSProperties }}` — CSS vars for origin
+
+---
+
+### 2. Add animation keyframes to `src/app/globals.css`
+
+```css
+.yarl__card-origin {
+  animation: yarlCardOpen 0.22s ease-out forwards;
+}
+@keyframes yarlCardOpen {
+  from {
+    opacity: 0;
+    transform: scale(0.08);
+    transform-origin: var(--card-ox, 50%) var(--card-oy, 50%);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    transform-origin: var(--card-ox, 50%) var(--card-oy, 50%);
+  }
+}
+```
+
+This causes the lightbox backdrop + image to zoom in from the card's center, giving the anchored feel.
+
+---
+
+### 3. Update `src/core/components/FeedPostCard/FeedPostCard.tsx`
+
+- Add `images?: string[]` to `FeedPostCardProps` alongside existing `image: string`
+- Replace the current `<div className="relative w-full aspect-[4/3] ...">` image block with `<FeedImageCarousel images={post.images?.length ? post.images : post.image ? [post.image] : []} aspectRatio="aspect-[4/3]" />`
+- All other sections (header, text, source card, actions) remain untouched
+
+---
+
+### 4. Update `src/app/feed/page.tsx` — `transformFeedData`
+
+- In the existing function, add `images: sortedImages.map(img => img.imageUrl)` to the returned object (alongside the already-present `image: firstImage?.imageUrl || ''`)
+- No other changes to this file — GraphQL query, pagination, infinite scroll all unchanged
+
+---
+
+### 5. Update `src/features/user/components/UserPostsList.tsx`
+
+- Replace the current `{feed.images && feed.images.length > 0 && <div className="relative w-full aspect-video ..."><Image src={feed.images[0].imageUrl} .../></div>}` block with `<FeedImageCarousel images={feed.images.map(img => img.imageUrl)} aspectRatio="aspect-video" />`
+- All other sections (header, text, edit/delete menus, like/comment) remain untouched
+
+---
+
+## Verification
+
+- Home feed: posts with multiple images show carousel arrows + dots; clicking any image opens lightbox at correct index zooming from card; single-image posts open lightbox directly
+- Profile feed: same behavior using `aspect-video` (16:9) ratio
+- Lightbox: Zoom plugin works (pinch/scroll zoom); swipe/arrow nav between slides when multi-image; Escape / click-outside / close button all dismiss; 16:9 content displays in `contain` mode (no cropping)
+- Existing layout/styling of card header, text, source link, and action buttons is unchanged
+- No new libraries introduced; only `Zoom` plugin imported from `yet-another-react-lightbox/plugins/zoom`
+
+---
+
+## Decisions
+
+- Lightbox: full-screen overlay with CSS `transform-origin` zoom-from-card keyframe animation (via `classNames.root` + CSS custom property `--card-ox`/`--card-oy`), rather than a DOM-contained sub-lightbox
+- Card aspect ratio: preserved as-is (`4/3` for home feed, `16/9` for profile); only lightbox uses `imageFit: 'contain'` to enforce no-crop display
+- Carousel: CSS `scroll-snap` + arrow buttons (native touch swipe on mobile, clickable arrows on desktop)
+- `FeedPostCard` interface: `images?: string[]` added optionally, `image: string` kept for backward compat; fallback chain is `images[]` → `[image]` → `[]`

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -127,6 +127,7 @@ const FeedPage = () => {
       time: formatRelativeTime(feed.createdAt),
       text: feed.content,
       image: firstImage?.imageUrl || '',
+      images: sortedImages.map((img) => img.imageUrl),
       source: {
         title: feed.recipeId ? 'View Recipe' : 'Tasteplorer',
         url: feed.recipeId ? `/recipes/${feed.recipeId}` : '#',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,20 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* Lightbox zoom-from-card opening animation */
+.yarl__card-origin {
+  animation: yarlCardOpen 0.22s ease-out forwards;
+}
+@keyframes yarlCardOpen {
+  from {
+    opacity: 0;
+    transform: scale(0.08);
+    transform-origin: var(--yarl__card-ox, 50%) var(--yarl__card-oy, 50%);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    transform-origin: var(--yarl__card-ox, 50%) var(--yarl__card-oy, 50%);
+  }
+}

--- a/src/core/components/FeedImageCarousel/FeedImageCarousel.tsx
+++ b/src/core/components/FeedImageCarousel/FeedImageCarousel.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
+import Lightbox from 'yet-another-react-lightbox';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+import 'yet-another-react-lightbox/styles.css';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+
+interface FeedImageCarouselProps {
+  /** Ordered list of image URLs to display. */
+  images: string[];
+  /** Tailwind aspect-ratio class applied to the card image area (e.g. "aspect-[4/3]" or "aspect-video"). */
+  aspectRatio?: string;
+}
+
+const FeedImageCarousel: React.FC<FeedImageCarouselProps> = ({
+  images,
+  aspectRatio = 'aspect-[4/3]',
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [originX, setOriginX] = useState('50%');
+  const [originY, setOriginY] = useState('50%');
+
+  const count = images.length;
+  const slides = images.map((src) => ({ src }));
+
+  // Track the active slide index by listening to scroll events on the scroll container.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || count <= 1) return;
+
+    const handleScroll = () => {
+      const index = Math.round(el.scrollLeft / el.offsetWidth);
+      setActiveIndex(Math.max(0, Math.min(index, count - 1)));
+    };
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [count]);
+
+  const scrollToIndex = useCallback((index: number) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ left: index * el.offsetWidth, behavior: 'smooth' });
+  }, []);
+
+  const handlePrev = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    scrollToIndex(Math.max(0, activeIndex - 1));
+  };
+
+  const handleNext = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    scrollToIndex(Math.min(count - 1, activeIndex + 1));
+  };
+
+  const openLightbox = (index: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (rect) {
+      setOriginX(
+        (((rect.left + rect.width / 2) / window.innerWidth) * 100).toFixed(1) +
+          '%'
+      );
+      setOriginY(
+        (((rect.top + rect.height / 2) / window.innerHeight) * 100).toFixed(1) +
+          '%'
+      );
+    }
+    setLightboxIndex(index);
+    setOpen(true);
+  };
+
+  if (!count) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative w-full ${aspectRatio} bg-gray-100 overflow-hidden`}
+    >
+      {/* ── Scroll container ── */}
+      <div
+        ref={scrollRef}
+        className="flex w-full h-full overflow-x-auto snap-x snap-mandatory scrollbar-hide"
+      >
+        {images.map((src, i) => (
+          <div
+            key={i}
+            className="relative flex-none w-full h-full snap-center cursor-pointer"
+            onClick={() => openLightbox(i)}
+            role="button"
+            tabIndex={0}
+            aria-label={`View image ${i + 1} of ${count}`}
+            onKeyDown={(e) => e.key === 'Enter' && openLightbox(i)}
+          >
+            <Image
+              src={src}
+              alt={`Post image ${i + 1}`}
+              fill
+              className="object-cover transition-transform duration-200 hover:scale-105"
+              sizes="(max-width: 768px) 100vw, 672px"
+            />
+            {/* Subtle overlay */}
+            <div className="absolute inset-0 bg-black/10 pointer-events-none" />
+          </div>
+        ))}
+      </div>
+
+      {/* ── Prev / Next arrows (multi-image only) ── */}
+      {count > 1 && (
+        <>
+          <button
+            onClick={handlePrev}
+            disabled={activeIndex === 0}
+            aria-label="Previous image"
+            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-black/40 hover:bg-black/60 text-white rounded-full w-8 h-8 flex items-center justify-center transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            <FaChevronLeft size={14} />
+          </button>
+
+          <button
+            onClick={handleNext}
+            disabled={activeIndex === count - 1}
+            aria-label="Next image"
+            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-black/40 hover:bg-black/60 text-white rounded-full w-8 h-8 flex items-center justify-center transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            <FaChevronRight size={14} />
+          </button>
+
+          {/* ── Dot indicators ── */}
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5">
+            {images.map((_, i) => (
+              <button
+                key={i}
+                aria-label={`Go to image ${i + 1}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  scrollToIndex(i);
+                }}
+                className={`h-1.5 rounded-full transition-all duration-200 ${
+                  i === activeIndex ? 'bg-white w-3' : 'bg-white/60 w-1.5'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* ── Lightbox ── */}
+      <Lightbox
+        open={open}
+        close={() => setOpen(false)}
+        index={lightboxIndex}
+        slides={slides}
+        plugins={[Zoom]}
+        carousel={{ imageFit: 'contain', finite: true }}
+        animation={{ fade: 220 }}
+        className="yarl__card-origin"
+        styles={{
+          root: {
+            '--yarl__card-ox': originX,
+            '--yarl__card-oy': originY,
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default FeedImageCarousel;

--- a/src/core/components/FeedPostCard/FeedPostCard.tsx
+++ b/src/core/components/FeedPostCard/FeedPostCard.tsx
@@ -7,6 +7,7 @@ import {
   FaEllipsisH,
 } from 'react-icons/fa';
 import Image from 'next/image';
+import FeedImageCarousel from '@/core/components/FeedImageCarousel/FeedImageCarousel';
 
 interface FeedPostCardProps {
   post: {
@@ -16,6 +17,7 @@ interface FeedPostCardProps {
     time: string;
     text: string;
     image: string;
+    images?: string[];
     source: { title: string; url: string; image: string };
     liked: boolean;
     bookmarked: boolean;
@@ -81,21 +83,16 @@ const FeedPostCard: React.FC<FeedPostCardProps> = ({ post, className }) => {
         </button>
       </div>
       {/* Image */}
-      <div className="relative w-full aspect-[4/3] bg-gray-100 overflow-hidden">
-        {post.image && post.image.trim() !== '' ? (
-          <Image
-            src={post.image}
-            alt="Post"
-            fill
-            className="object-cover transition-transform duration-200 hover:scale-105"
-            sizes="(max-width: 768px) 100vw, 672px"
-          />
-        ) : (
-          <div className="w-full h-full bg-gray-200 flex items-center justify-center text-gray-400">
-            <span className="text-sm">No Image Available</span>
-          </div>
-        )}
-      </div>
+      <FeedImageCarousel
+        images={
+          post.images && post.images.length > 0
+            ? post.images
+            : post.image
+              ? [post.image]
+              : []
+        }
+        aspectRatio="aspect-[4/3]"
+      />
       {/* Text */}
       <div className="px-5 pt-3 pb-1">
         <p className="text-gray-800 text-base leading-relaxed whitespace-pre-line break-words">

--- a/src/features/user/components/UserPostsList.tsx
+++ b/src/features/user/components/UserPostsList.tsx
@@ -10,6 +10,7 @@ import FeedForm from '@/features/feed/components/FeedForm';
 import DeleteConfirmationModal from '@/features/feed/components/DeleteConfirmationModal';
 import useSnackbar from '@/core/hooks/useSnackbar';
 import Image from 'next/image';
+import FeedImageCarousel from '@/core/components/FeedImageCarousel/FeedImageCarousel';
 
 interface FeedImage {
   id: string;
@@ -279,15 +280,10 @@ export const UserPostsList: React.FC<UserPostsListProps> = ({
 
             {/* Images */}
             {feed.images && feed.images.length > 0 && (
-              <div className="relative w-full aspect-video bg-gray-100 overflow-hidden">
-                <Image
-                  src={feed.images[0].imageUrl}
-                  alt="Post"
-                  fill
-                  className="object-cover transition-transform duration-200 hover:scale-105"
-                  sizes="(max-width: 768px) 100vw, 672px"
-                />
-              </div>
+              <FeedImageCarousel
+                images={feed.images.map((img) => img.imageUrl)}
+                aspectRatio="aspect-video"
+              />
             )}
 
             {/* Actions placeholder */}


### PR DESCRIPTION
- Add FeedImageCarousel component (scroll-snap carousel, arrows, dots, keyboard & touch)
- Integrate yet-another-react-lightbox (Zoom plugin only) anchored to clicked card via transform-origin animation
- Ensure lightbox uses imageFit: contain (16:9 framing), zoom enabled, and finite navigation (no looping)
- Add subtle overlay (bg-black/10) on slides for depth
- Wire FeedPostCard, UserPostsList and transformFeedData to pass image arrays
- Add animation keyframes to globals.css

No API/GraphQL changes; layout and existing behaviors preserved.

Files:
- src/core/components/FeedImageCarousel/FeedImageCarousel.tsx
- src/core/components/FeedPostCard/FeedPostCard.tsx
- src/features/user/components/UserPostsList.tsx
- src/app/feed/page.tsx
- src/app/globals.css